### PR TITLE
Update GitHub Actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         python-version: ['3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run regression tests

--- a/RELEASE_MANIFEST.json
+++ b/RELEASE_MANIFEST.json
@@ -16,7 +16,7 @@
     {
       "path": ".github/workflows/ci.yml",
       "bytes": 766,
-      "sha256": "7edad7bec5fd18a6462a8b797ad059091df99d1cdc72d284f1d08b6bb282fd1c"
+      "sha256": "1744cb4a9afed10655513ed3f67cc71e10ada989b4a08f64df12c7fd3f3d6602"
     },
     {
       "path": ".gitignore",


### PR DESCRIPTION
Updates the official checkout and setup-python actions to v7, then refreshes the release manifest so integrity checks remain valid. Local release gate: 250/250 tests passed.