### PR TITLE
Run archived verification locally with independent API status

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,35 @@ python3 experiments/historical_compare.py audit \
   --output reports/historical-2023-audit-local.json
 ```
 
+### Re-execute archived comparisons locally
+
+This source-checkout command runs the current verification code against saved
+model responses. It requires no API key, SDK, network connection, or local model.
+It is deterministic response replay and does not generate new model answers.
+
+```bash
+python3 experiments/local_replay.py \
+  --archive reports/historical-2023-pilot2-v3-live-001 \
+  --inputs experiments/historical-2023-pilot2-v3/inputs.json \
+  --sources experiments/historical-2023-pilot2-v3/sources.json \
+  --freeze experiments/historical-2023-pilot2-v3/freeze.json \
+  --gold experiments/historical-2023-pilot2-v3/gold.json \
+  --output reports/local-replay-my-run
+```
+
+API status is `not_used` with zero requests. `execution_status` reports whether
+the archived calls could be replayed; `verification_status` separately retains
+semantic failures. This pilot replays all six case/arm/control combinations,
+including the known staged Lucid full-evidence error. Exit code 1 means replay
+or verification errors were retained; exit code 2 means setup or archive
+validation failed. Use a fresh output directory for each run.
+
+Call hashes and exact requests are checked before accepting saved responses.
+Optional gold labels are opened after replay, and scores are explicitly marked
+`archived_response_replay`. They do not constitute a new accuracy measurement.
+An invalid API key cannot block this local path. Fresh model inference still
+requires a separately configured model runtime.
+
 ### Run a model-backed comparison
 
 The experimental runtime is source-checkout-only. Install the pinned optional

--- a/RELEASE_MANIFEST.json
+++ b/RELEASE_MANIFEST.json
@@ -40,8 +40,8 @@
     },
     {
       "path": "README.md",
-      "bytes": 12071,
-      "sha256": "f1c46d08884862c8707b369c0965f64eb5a5185aa5a2e212f4ede54d1380a9ff"
+      "bytes": 13563,
+      "sha256": "93c33cd6c48aa4b6e5e0f6ee57c555c201703b2540e93f0c5c6b29211b1fbb5b"
     },
     {
       "path": "SECURITY.md",
@@ -247,6 +247,11 @@
       "path": "experiments/inputs-v03.json",
       "bytes": 7816,
       "sha256": "4efef214c4c2d220407ee05c775945fad7377dc31328c07ccdad3842deb75cfc"
+    },
+    {
+      "path": "experiments/local_replay.py",
+      "bytes": 7515,
+      "sha256": "e14df18fe390c0610ef37ac1c23818f2d3540c3b1b3d531f177a0eed1cefb23e"
     },
     {
       "path": "experiments/loop_compare.py",
@@ -1797,6 +1802,11 @@
       "path": "tests/test_historical_compare.py",
       "bytes": 49833,
       "sha256": "0bf9d7f6ec8a3d8ee3e7fc1b31b697ff661aad1253745fb7a12241d9526c65ef"
+    },
+    {
+      "path": "tests/test_local_replay.py",
+      "bytes": 5360,
+      "sha256": "c71dc00e1e0024bb66f406235bc7d363310a89c586c22a287e353a603c2924f7"
     },
     {
       "path": "tests/test_provenance.py",

--- a/experiments/local_replay.py
+++ b/experiments/local_replay.py
@@ -1,0 +1,161 @@
+"""Re-execute archived verification locally without API authentication or calls.
+
+This is deterministic response replay, not new local-model inference. API
+availability, replay execution, and semantic verification have separate states.
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+import time
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import historical_compare as historical
+from model_io import write
+from newsverify.decisions import present_decision
+
+
+def replay(args):
+    archive = Path(args.archive).resolve()
+    output = Path(args.output).resolve()
+    if output.exists():
+        raise FileExistsError("Output already exists; choose a new run directory")
+    validated = historical.validate_inference(
+        args.inputs, args.sources, args.freeze)
+    config = historical._json(archive / "config.json")
+    for key in ("input_sha256", "sources_sha256", "freeze_sha256"):
+        if config.get(key) != validated[key]:
+            raise ValueError("Archive and frozen inputs differ: " + key)
+    cases = validated["inputs"]["cases"]
+    prepared = []
+    # Validate both arms before replay. Archived token use belongs to the old
+    # run and is never added to this run's API usage.
+    for arm, mode in historical.ARM_ORDER:
+        rows = historical._json(archive / arm / "results.json")
+        historical._validate_raw_rows(rows, cases)
+        historical._validate_call_logs(
+            archive / arm, rows, config["model"],
+            config["reasoning_effort"], config["budget"])
+        for case in cases:
+            identifier = case["target"]["id"]
+            if Path(identifier).name != identifier or identifier in {".", ".."}:
+                raise ValueError("Case id is not a safe artifact name")
+            variants = [("loop", "loop")]
+            if case["full_evidence_control"]:
+                variants.append(("full_evidence_once", "full"))
+            for variant, suffix in variants:
+                path = archive / arm / f"{identifier}-{suffix}-calls.json"
+                prepared.append((arm, mode, case, variant, suffix,
+                                 historical._json(path)))
+
+    output.mkdir(parents=True, exist_ok=False)
+    started = time.monotonic()
+    report = {
+        "schema_version": 1,
+        "execution_mode": "local_replay",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "execution_status": "running",
+        "verification_status": "not_checked",
+        "api": {"required": False, "status": "not_used", "requests": 0},
+        "new_model_inference": False,
+        "new_accuracy_measurement": False,
+        "gold_access_during_replay": False,
+        "input_sha256": validated["input_sha256"],
+        "archive_config_sha256": historical._sha(archive / "config.json"),
+        "executed_source_sha256": historical.loop_compare.source_hashes(),
+        "archived_model": config["model"],
+        "results": [],
+        "replayed_call_records": 0,
+        "scores": None,
+    }
+    write(output / "results.json", report)
+    for arm, mode, case, variant, suffix, records in prepared:
+        identifier = case["target"]["id"]
+        row = {"arm": arm, "id": identifier, "variant": variant}
+        try:
+            trace = historical._offline_replay_trace(
+                case, variant, mode, config["trace_config"],
+                config["max_inner_repairs"][arm], records,
+                config["model"], config["reasoning_effort"], config["budget"])
+            filename = f"{arm}-{identifier}-{suffix}-trace.json"
+            write(output / filename, trace)
+            prediction = present_decision(trace)
+            row.update(
+                execution_status="completed",
+                verification_status=("completed" if prediction["assessment_valid"]
+                                     else "error"),
+                prediction=prediction, errors=trace["errors"],
+                replayed_call_records=len(records), trace=filename)
+            report["replayed_call_records"] += len(records)
+        except (ValueError, RuntimeError) as exc:
+            # A request/log mismatch is a replay error, never a new decision.
+            row.update(execution_status="error", verification_status="not_checked",
+                       prediction=None, error_type=type(exc).__name__,
+                       error=str(exc))
+        report["results"].append(row)
+        write(output / "results.json", report)
+
+    replay_failed = any(row["execution_status"] != "completed"
+                        for row in report["results"])
+    report["execution_status"] = "has_errors" if replay_failed else "completed"
+    report["verification_status"] = (
+        "has_errors" if any(row["verification_status"] == "error"
+                            for row in report["results"])
+        else "incomplete" if replay_failed else "completed")
+    write(output / "results.json", report)
+
+    # Gold is opened only after every replay has finished. Refuse a score if
+    # a request could not be replayed; semantic failures remain in the results.
+    if args.gold and not replay_failed:
+        try:
+            gold = historical.validate_all(
+                args.inputs, args.sources, args.gold, args.freeze)["gold"]
+            labels = {case["id"]: case["decision"] for case in gold["cases"]}
+            scores = {"kind": "archived_response_replay", "main_cases": {}}
+            for arm, _ in historical.ARM_ORDER:
+                rows = [row for row in report["results"]
+                        if row["arm"] == arm and row["variant"] == "loop"]
+                correct = sum(row["prediction"]["assessment_valid"]
+                              and row["prediction"]["decision"] == labels[row["id"]]
+                              for row in rows)
+                scores["main_cases"][arm] = {
+                    "correct": correct, "total": len(rows),
+                    "accuracy": correct / len(rows) if rows else None,
+                }
+            report["scores"] = scores
+        except ValueError as exc:
+            report["execution_status"] = "has_errors"
+            report["scoring_error"] = str(exc)
+    report["local_seconds"] = round(time.monotonic() - started, 6)
+    write(output / "results.json", report)
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    for name in ("archive", "inputs", "sources", "freeze", "output"):
+        parser.add_argument("--" + name, required=True)
+    parser.add_argument("--gold", help="Optional frozen labels; opened after replay")
+    args = parser.parse_args()
+    try:
+        report = replay(args)
+    except (ValueError, OSError) as exc:
+        print(f"Local replay blocked: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+    print("API: not used (0 requests)")
+    print("Local replay:", report["execution_status"])
+    print("Verification:", report["verification_status"])
+    print("Archived calls replayed:", report["replayed_call_records"])
+    if report["scores"]:
+        for arm, score in report["scores"]["main_cases"].items():
+            print(f"{arm}: {score['correct']}/{score['total']} (saved-output replay)")
+    print("New model inference: no")
+    print("Results:", Path(args.output).resolve() / "results.json")
+    return int(report["execution_status"] != "completed"
+               or report["verification_status"] != "completed")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_local_replay.py
+++ b/tests/test_local_replay.py
@@ -1,0 +1,101 @@
+"""Offline execution must not inherit API auth or hide semantic failures."""
+from argparse import Namespace
+from copy import deepcopy
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "experiments"))
+import local_replay
+
+
+class LocalReplayTests(unittest.TestCase):
+    def args(self, output, gold=True):
+        data = ROOT / "experiments/historical-2023-pilot2-v3"
+        return Namespace(
+            archive=str(ROOT / "reports/historical-2023-pilot2-v3-live-001"),
+            inputs=str(data / "inputs.json"), sources=str(data / "sources.json"),
+            freeze=str(data / "freeze.json"),
+            gold=str(data / "gold.json") if gold else None, output=str(output))
+
+    def test_runs_without_network_or_credentials_and_retains_control_error(self):
+        for auth in ({}, {"OPENAI_API_KEY": "invalid-test-value"}):
+            with self.subTest(configured=bool(auth)), tempfile.TemporaryDirectory() as tmp:
+                with patch.dict(os.environ, auth, clear=True), \
+                        patch("socket.socket", side_effect=AssertionError("network forbidden")), \
+                        patch.object(local_replay.historical.loop_compare, "BudgetClient",
+                                     side_effect=AssertionError("API client forbidden")):
+                    report = local_replay.replay(self.args(Path(tmp) / "run"))
+                self.assertEqual("completed", report["execution_status"])
+                self.assertEqual("has_errors", report["verification_status"])
+                self.assertEqual({"required": False, "status": "not_used", "requests": 0}, report["api"])
+                self.assertFalse(report["new_model_inference"])
+                self.assertFalse(report["new_accuracy_measurement"])
+                self.assertEqual(52, report["replayed_call_records"])
+                self.assertEqual(6, len(report["results"]))
+                failures = [row for row in report["results"]
+                            if row["verification_status"] == "error"]
+                self.assertEqual(1, len(failures))
+                self.assertEqual("staged", failures[0]["arm"])
+                self.assertEqual("full_evidence_once", failures[0]["variant"])
+                self.assertIn("conclusive probe", failures[0]["errors"][0]["message"])
+                scores = report["scores"]["main_cases"]
+                self.assertEqual((1, 2), (scores["monolithic"]["correct"], scores["staged"]["correct"]))
+
+    def test_gold_is_optional_and_only_opened_after_all_replays(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            original = local_replay.historical.validate_all
+            output = Path(tmp) / "scored"
+            def validate_after_replay(*args):
+                report = json.loads((output / "results.json").read_text())
+                self.assertEqual(6, len(report["results"]))
+                self.assertEqual("completed", report["execution_status"])
+                return original(*args)
+            with patch.object(local_replay.historical, "validate_all", side_effect=validate_after_replay):
+                self.assertIsNotNone(local_replay.replay(self.args(output))["scores"])
+            with patch.object(local_replay.historical, "validate_all", side_effect=AssertionError("gold forbidden")):
+                report = local_replay.replay(self.args(Path(tmp) / "unscored", gold=False))
+                self.assertIsNone(report["scores"])
+
+    def test_rejects_corrupted_call_output_before_replay(self):
+        original = local_replay.historical._json
+        def corrupted(path):
+            data = original(path)
+            if str(path).endswith("virgin-galactic-commercial-service-2023-loop-calls.json"):
+                data = deepcopy(data)
+                data[0]["output"] += " "
+            return data
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "run"
+            with patch.object(local_replay.historical, "_json", side_effect=corrupted):
+                with self.assertRaisesRegex(ValueError, "model output"):
+                    local_replay.replay(self.args(output))
+            self.assertFalse(output.exists())
+
+    def test_request_mismatch_is_execution_failure_without_score(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(local_replay.historical, "_offline_replay_trace",
+                              side_effect=ValueError("logged request mismatch")):
+                report = local_replay.replay(self.args(Path(tmp) / "run"))
+            self.assertEqual("has_errors", report["execution_status"])
+            self.assertEqual("incomplete", report["verification_status"])
+            self.assertEqual(6, len(report["results"]))
+            self.assertIsNone(report["scores"])
+            self.assertEqual(0, report["api"]["requests"])
+
+    def test_existing_output_is_preserved(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "keep.txt"
+            marker.write_text("original")
+            with self.assertRaises(FileExistsError):
+                local_replay.replay(self.args(tmp))
+            self.assertEqual("original", marker.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
API authentication failures currently prevent live comparisons, while users still need to execute and inspect the verification code locally.

This adds `experiments/local_replay.py`, a source-checkout command that runs both archived arms without an API key, SDK, or network connection. It separates API status (`not_used`), local execution status, and semantic verification status. Frozen inputs and call integrity are validated; every replayed request must match its saved request. Optional gold labels are opened after all replays. Results are explicitly marked as archived-response replay with no new model inference or accuracy measurement.

Validation: all 259 regression tests passed on Python 3.12.13. Five new tests cover missing/invalid credentials with networking and API client construction disabled, gold access ordering, corrupted outputs, request mismatches, and preserving prior output directories. The actual local command replayed all six case/arm/control combinations (52 saved calls) with zero API requests. Main cases reproduced 1/2 vs 2/2; the staged Lucid full-evidence diagnostic still raises the known stop-reason error and remains visible. This PR does not claim to fix that semantic defect.

The published tree matches the tested local tree exactly: `e0ea9e84a895888791be5301c7539a36d11c3632`. README usage and the release manifest are updated.