### PR TITLE
Add CPU local inference with pinned weights and no cloud fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dist/
 .env.*
 !.env.example
 private-data/
+.models/
+.local/
+.venv-local/

--- a/README.md
+++ b/README.md
@@ -160,6 +160,48 @@ python3 experiments/historical_compare.py audit \
   --output reports/historical-2023-audit-local.json
 ```
 
+### Run fresh verification on your own CPU
+
+The local model path loads GGUF weights with llama.cpp in a local Python worker.
+It generates new responses and executes the same staged or monolithic verifier.
+It requires no OpenAI SDK, API key, or hosted inference service. The worker
+disables networking and stops on errors or timeouts without cloud fallback.
+
+```bash
+python3 scripts/configure_local.py
+.venv-local/bin/python experiments/local_inference.py \
+  --config .local/model.json \
+  --output reports/my-local-inference
+```
+
+On Windows, run `python scripts/configure_local.py` and use
+`.venv-local\Scripts\python.exe` for the inference Python executable.
+Use Python 3.11 or later with an available llama.cpp CPU wheel; the initial
+installation and fresh inference were tested on Linux x86_64 with Python 3.12.
+Setup downloads the pinned 2.50 GB Qwen3-4B-Instruct-2507 Q4_K_M model and checks
+its SHA-256 before writing `.local/model.json`. The weights and machine-specific
+configuration are excluded from git. Only installation requires downloads;
+subsequent inference reads local files. CPU mode is the default, with up to
+eight threads and a 16,384-token context. The config permits a GPU layer count
+when a compatible llama.cpp build and hardware are supplied.
+
+The local command defaults to the staged loop. `--semantic-mode monolithic`
+selects the earlier adapter; `--case ID` selects one case. Controls are included
+only with `--include-controls`. Use a new output directory for every run.
+Generation runs sequentially against one loaded model, with per-case budgets
+and a worker deadline. If the worker times out it is stopped; no remote retry
+is possible. Raw local requests and outputs, usage, traces and errors are saved.
+The local decoder restricts source references to each layer's supplied material
+IDs. Missing scoped evidence cannot produce a conclusive dimension verdict.
+String and array length limits remain in the original prompts and Python gates;
+the sampling grammar omits them to avoid llama.cpp grammar expansion limits.
+
+Local tokens consume compute and memory but are not billed by a model API.
+Local latency and verification quality must be measured independently from the
+archived Astra results. No model download or successful installation alone
+establishes news accuracy. The snapshot provider still searches supplied
+materials rather than the open web.
+
 ### Re-execute archived comparisons locally
 
 This source-checkout command runs the current verification code against saved

--- a/RELEASE_MANIFEST.json
+++ b/RELEASE_MANIFEST.json
@@ -20,8 +20,8 @@
     },
     {
       "path": ".gitignore",
-      "bytes": 155,
-      "sha256": "a0e1a2960f8ec951997781d9b9218040b1ae56d6154f868cea99dc59bccda9f9"
+      "bytes": 185,
+      "sha256": "540352b37d3c202ee52d0f0e837c03915c141046b040b6b2d3dea8c4daa56e86"
     },
     {
       "path": "CHANGELOG.md",
@@ -40,8 +40,8 @@
     },
     {
       "path": "README.md",
-      "bytes": 13563,
-      "sha256": "93c33cd6c48aa4b6e5e0f6ee57c555c201703b2540e93f0c5c6b29211b1fbb5b"
+      "bytes": 15954,
+      "sha256": "cb8bfcb49420d6fd9502c824f448ec63586687095416bd5ea275f6ceddce522b"
     },
     {
       "path": "SECURITY.md",
@@ -247,6 +247,16 @@
       "path": "experiments/inputs-v03.json",
       "bytes": 7816,
       "sha256": "4efef214c4c2d220407ee05c775945fad7377dc31328c07ccdad3842deb75cfc"
+    },
+    {
+      "path": "experiments/local_inference.py",
+      "bytes": 6340,
+      "sha256": "bca14f7af21fe5a3b2246786aea1ac0d517552f290ecb9c0567312fa8d6e3b90"
+    },
+    {
+      "path": "experiments/local_model.py",
+      "bytes": 10687,
+      "sha256": "ad33f86aff7dfdffd22fb40bcd431c7d62b96f36cb358948ea97725451acdc18"
     },
     {
       "path": "experiments/local_replay.py",
@@ -1769,9 +1779,24 @@
       "sha256": "864975dac2eae9d255097e2c4cf343f87123ba1ed52fadba453723f01bd8f782"
     },
     {
+      "path": "requirements-local.txt",
+      "bytes": 125,
+      "sha256": "8f0751ab42c8aef9665dfcf1607d971bd1f270e4285d8040fe2339bf62136b49"
+    },
+    {
+      "path": "scripts/configure_local.py",
+      "bytes": 1296,
+      "sha256": "8b0b57249e331670a16d1c00b1bb7a96e12fc30908566f5136c3ac642f428a2e"
+    },
+    {
       "path": "scripts/release_manifest.py",
       "bytes": 2133,
       "sha256": "01f16e86bc3c813d2726082f225ec10383c542a297677d94856ae4564ba60508"
+    },
+    {
+      "path": "scripts/setup_local_model.py",
+      "bytes": 3154,
+      "sha256": "c51857723f1e0b0201e3c952ea785b8eab242dfb2bf10b9935bdfab51716de85"
     },
     {
       "path": "scripts/validate_release.py",
@@ -1802,6 +1827,11 @@
       "path": "tests/test_historical_compare.py",
       "bytes": 49833,
       "sha256": "0bf9d7f6ec8a3d8ee3e7fc1b31b697ff661aad1253745fb7a12241d9526c65ef"
+    },
+    {
+      "path": "tests/test_local_model.py",
+      "bytes": 9940,
+      "sha256": "8d69b104649dc6aed15d14ad67682348ebd941eb2bc0e23f3fad6aae84daff61"
     },
     {
       "path": "tests/test_local_replay.py",

--- a/experiments/local_inference.py
+++ b/experiments/local_inference.py
@@ -1,0 +1,115 @@
+"""Run fresh claim verification with local GGUF weights and zero cloud model calls."""
+import argparse
+from dataclasses import asdict
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import loop_compare as loop
+from local_model import LocalTransport
+from model_io import Budget, BudgetClient, write
+
+
+def run(args):
+    cases = loop.load_inputs(args.inputs)["cases"]
+    if args.case:
+        cases = [case for case in cases if case["target"]["id"] == args.case]
+        if not cases:
+            raise ValueError("Requested case does not exist")
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=False)
+    config = {
+        "execution_mode": "local_model_inference", "new_model_inference": True,
+        "cloud_api": {"required": False, "requests": 0, "fallback": False},
+        "semantic_mode": args.semantic_mode, "max_rounds": args.max_rounds,
+        "input_sha256": hashlib.sha256(Path(args.inputs).read_bytes()).hexdigest(),
+        "source_sha256": loop.source_hashes(),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "gold_access_during_inference": False,
+    }
+    write(out / "config.json", config)
+    budget = Budget(calls=args.max_calls, output_tokens=128000,
+                    per_call_output_tokens=8000, seconds=args.case_seconds)
+    results = []
+    try:
+        with LocalTransport(args.config) as transport:
+            config.update(local_model=transport.config, model=transport.model_id,
+                          budget=asdict(budget), network_disabled_in_worker=True)
+            write(out / "config.json", config)
+            jobs = [(case, False) for case in cases]
+            if args.include_controls:
+                jobs += [(case, True) for case in cases if case["full_evidence_control"]]
+            for case, full in jobs:
+                identifier = case["target"]["id"] + ("-full" if full else "-loop")
+                if Path(identifier).name != identifier:
+                    raise ValueError("Unsafe case id")
+                class RecordedClient(BudgetClient):
+                    def call(self, *values, **options):
+                        try:
+                            return super().call(*values, **options)
+                        finally:
+                            write(out / f"{identifier}-calls.json", self.records)
+                            write(out / "local-runtime-calls.json", transport.records)
+                            print(json.dumps({"case": identifier, "local_calls": self.calls,
+                                              "cloud_calls": 0}), flush=True)
+                client = RecordedClient(transport.model_id, budget, transport=transport)
+                materials = [loop.p.MaterialVersion(**item) for item in case["materials"]]
+                seeds = [item.version_id for item in materials] if full else case["seed_ids"]
+                provider = loop.SnapshotSearchProvider(materials, seeds)
+                target = loop.p.Target(**{**case["target"], "evidence_scope": tuple(case["target"]["evidence_scope"])})
+                if args.semantic_mode == "staged":
+                    decomposer = loop.StagedDecomposer(client, max_repairs=1)
+                    verifier = loop.StagedVerifier(client, max_repairs=1)
+                else:
+                    decomposer = loop.MonolithicDecomposer(client)
+                    verifier = loop.MonolithicVerifier(client)
+                trace = loop.p.run_provenance(
+                    target, provider, decomposer, verifier,
+                    loop.p.TraceConfig(max_rounds=1 if full else args.max_rounds,
+                                       max_documents=18, max_decomposition_calls=18))
+                write(out / f"{identifier}-trace.json", trace)
+                write(out / f"{identifier}-retrieval.json", provider.history)
+                if args.semantic_mode == "staged":
+                    write(out / f"{identifier}-stages.json", {
+                        "decomposition": decomposer.history, "verification": verifier.history})
+                row = {"id": case["target"]["id"], "variant": "full_evidence_once" if full else "loop",
+                       "status": "completed" if trace["assessment_valid"] else "error",
+                       "prediction": loop.present_decision(trace), "errors": trace["errors"],
+                       "local_usage": client.usage(), "cloud_api_calls": 0}
+                results.append(row)
+                write(out / "results.json", results)
+                print(json.dumps({"case": identifier, "status": row["status"],
+                                  "decision": row["prediction"]["decision"]}), flush=True)
+        status = {"status": "completed" if all(row["status"] == "completed" for row in results) else "has_errors",
+                  "new_model_inference": True, "local_model_calls": sum(row["local_usage"]["model_calls"] for row in results),
+                  "cloud_api_calls": 0, "results": len(results)}
+    except (OSError, ValueError, RuntimeError, ImportError) as exc:
+        status = {"status": "local_runtime_error", "error_type": type(exc).__name__,
+                  "error": str(exc), "cloud_api_calls": 0, "fallback": False}
+    write(out / "status.json", status)
+    print(json.dumps(status), flush=True)
+    return int(status["status"] != "completed")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=".local/model.json")
+    parser.add_argument("--inputs", default="experiments/historical-2023-pilot2-v3/inputs.json")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--case")
+    parser.add_argument("--semantic-mode", choices=["staged", "monolithic"], default="staged")
+    parser.add_argument("--max-rounds", type=int, choices=range(1, 11), default=3)
+    parser.add_argument("--max-calls", type=int, default=40)
+    parser.add_argument("--case-seconds", type=int, default=900)
+    parser.add_argument("--include-controls", action="store_true")
+    args = parser.parse_args()
+    if args.max_calls < 1 or args.case_seconds < 1:
+        parser.error("max-calls and case-seconds must be positive")
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/local_model.py
+++ b/experiments/local_model.py
@@ -1,0 +1,223 @@
+"""Direct local llama.cpp inference in a bounded worker; no HTTP or cloud fallback."""
+from copy import deepcopy
+import hashlib
+import json
+import multiprocessing
+from pathlib import Path
+import socket
+import time
+from types import SimpleNamespace
+
+
+def _deny_network(*args, **kwargs):
+    raise RuntimeError("Network access is disabled in the local inference worker")
+
+
+def sampling_schema(value):
+    """Avoid exponential grammar expansion; full bounds remain in Python gates.
+
+    llama.cpp expands bounded strings/arrays into repetitions. Nested stage
+    schemas can exceed its grammar limits. Only the sampling grammar omits
+    those bounds; the model sees the original schema and the existing staged
+    validators still check every original length/cardinality bound.
+    """
+    if isinstance(value, dict):
+        return {key: sampling_schema(child) for key, child in value.items()
+                if key not in {"minLength", "maxLength", "minItems", "maxItems"}}
+    if isinstance(value, list):
+        return [sampling_schema(child) for child in value]
+    return value
+
+
+def scoped_sampling_schema(schema, messages):
+    """Limit source references to the actual layer input, never target metadata.
+
+    These constraints narrow decoding only. They do not create evidence or
+    replace the existing staged schema, quote, scope, and grounding gates.
+    """
+    result = sampling_schema(schema)
+    try:
+        payload = json.loads(messages[-1]["content"])
+    except (KeyError, IndexError, TypeError, json.JSONDecodeError):
+        return result
+    if not isinstance(payload, dict) or not isinstance(payload.get("materials"), list):
+        return result
+    versions = sorted({item["version_id"] for item in payload["materials"]})
+
+    def constrain(node):
+        if not isinstance(node, dict):
+            return
+        properties = node.get("properties", {})
+        if node.get("type") == "array":
+            item_properties = node.get("items", {}).get("properties", {})
+            if {"version_id", "quote"} <= item_properties.keys():
+                if versions:
+                    item_properties["version_id"]["enum"] = versions
+                else:
+                    # A zero-length array has a small, bounded grammar.
+                    node["maxItems"] = 0
+        if {"dimension", "verdict", "basis_indices"} <= properties.keys():
+            if not versions or payload.get("missing_scope"):
+                properties["verdict"]["enum"] = ["unresolved"]
+            if not versions:
+                properties["basis_indices"]["maxItems"] = 0
+        for child in node.values():
+            if isinstance(child, dict):
+                constrain(child)
+            elif isinstance(child, list):
+                for item in child:
+                    constrain(item)
+    constrain(result)
+    return result
+
+
+def _worker(pipe, config):
+    # The pipe already exists. Inference cannot create a network connection,
+    # even if a future dependency were to try to download or contact a service.
+    try:
+        from llama_cpp import Llama
+        socket.socket = _deny_network
+        socket.create_connection = _deny_network
+        llm = Llama(
+            model_path=config["model_path"], n_ctx=config["context_tokens"],
+            n_threads=config["threads"], n_threads_batch=config["threads"],
+            n_gpu_layers=config["gpu_layers"], seed=config["seed"],
+            n_batch=512, chat_format="chatml", verbose=False)
+        pipe.send({"ready": True})
+        while True:
+            request = pipe.recv()
+            if request is None:
+                break
+            try:
+                pipe.send({"response": llm.create_chat_completion(**request)})
+            except Exception as exc:
+                pipe.send({"error_type": type(exc).__name__, "error": str(exc)})
+        llm.close()
+    except Exception as exc:
+        pipe.send({"error_type": type(exc).__name__, "error": str(exc)})
+    finally:
+        pipe.close()
+
+
+def load_config(path):
+    path = Path(path).expanduser().resolve()
+    config = json.loads(path.read_text())
+    if config.get("backend") != "llama_cpp_local_process":
+        raise ValueError("Local inference requires backend=llama_cpp_local_process")
+    if config.get("cloud_fallback") is not False:
+        raise ValueError("Local inference requires cloud_fallback=false")
+    model = (path.parent / config["model_path"]).resolve()
+    if not model.is_file():
+        raise FileNotFoundError("Local GGUF model is missing; run setup_local_model.py")
+    with model.open("rb") as stream:
+        actual_hash = hashlib.file_digest(stream, "sha256").hexdigest()
+    if actual_hash != config.get("model_sha256"):
+        raise ValueError("Local model checksum mismatch")
+    for name in ("context_tokens", "threads", "call_timeout_seconds"):
+        if type(config.get(name)) is not int or config[name] < 1:
+            raise ValueError(name + " must be a positive integer")
+    if type(config.get("seed")) is not int or type(config.get("gpu_layers")) is not int:
+        raise ValueError("seed and gpu_layers must be integers")
+    return {**config, "model_path": str(model)}
+
+
+class LocalTransport:
+    """Translate the existing client contract to a local process, never a URL."""
+    def __init__(self, config_path):
+        self.config = load_config(config_path)
+        self.model_id = "local/" + Path(self.config["model_path"]).stem
+        self.records = []
+        context = multiprocessing.get_context("spawn")
+        self.pipe, child = context.Pipe()
+        self.process = context.Process(target=_worker, args=(child, self.config), daemon=True)
+        self.process.start()
+        child.close()
+        if not self.pipe.poll(90):
+            self.close()
+            raise TimeoutError("Local model loading timed out")
+        ready = self.pipe.recv()
+        if ready.get("ready") is not True:
+            self.close()
+            raise RuntimeError("Local model loading failed: " + ready.get("error", "unknown"))
+
+    def __call__(self, **kwargs):
+        if not self.process.is_alive():
+            raise RuntimeError("Local worker is unavailable; cloud fallback is disabled")
+        if kwargs.get("model") != self.model_id:
+            raise ValueError("Requested model differs from the loaded local model")
+        if kwargs.get("reasoning_effort"):
+            raise ValueError("reasoning_effort is not a supported local sampling setting")
+        messages = deepcopy(kwargs["messages"])
+        response_format = kwargs.get("response_format")
+        local_format = None
+        if response_format:
+            local_format = {"type": "json_object"}
+            if response_format["type"] == "json_schema":
+                schema = response_format["json_schema"]["schema"]
+                local_format["schema"] = scoped_sampling_schema(schema, messages)
+                messages[0]["content"] += (
+                    "\nReturn only JSON matching this exact schema; keep strings concise:\n"
+                    + json.dumps(schema, ensure_ascii=False, separators=(",", ":")))
+                messages[0]["content"] += (
+                    "\nUse empty notes unless an essential ambiguity needs recording. "
+                    "Each rationale should be one short sentence. "
+                    "If the schema has citations, these are references to OTHER sources "
+                    "explicitly identifiable in the source BODY, not the current material's "
+                    "own URL from metadata and not a list of its factual claims. "
+                    "A metadata URL is never source-side citation evidence. "
+                    "When no external reference is visible, return citations: []. "
+                    "The origin field may still identify the current original record.")
+                if "probe_results" in schema.get("properties", {}):
+                    messages[0]["content"] += (
+                        "\nFor verification layers, only materials contains admissible evidence; "
+                        "the target and its source_version_id are not evidence. "
+                        "With materials=[], use basis_pool=[], basis_indices=[], and unresolved "
+                        "for every required dimension. With missing_scope nonempty, use gaps=[] "
+                        "and stop_reason=scope_unavailable; the program retrieves those versions. "
+                        "Do not invent extra target qualifiers: scope_location concerns the scope "
+                        "stated in the target, not an unstated geographic location.")
+        request = {"messages": messages, "model": self.model_id,
+                   "temperature": 0.0, "seed": self.config["seed"],
+                   "max_tokens": kwargs["max_completion_tokens"],
+                   "response_format": local_format, "stream": False}
+        record = {"request": request, "status": "running"}
+        self.records.append(record)
+        started = time.monotonic()
+        self.pipe.send(request)
+        timeout = min(float(kwargs["timeout"]), self.config["call_timeout_seconds"])
+        if not self.pipe.poll(max(0, timeout)):
+            record.update(status="error", error_type="TimeoutError", seconds=time.monotonic() - started)
+            self.close()
+            raise TimeoutError("Local inference deadline exceeded; worker stopped")
+        try:
+            result = self.pipe.recv()
+        except (EOFError, OSError) as exc:
+            record.update(status="error", error_type=type(exc).__name__,
+                          error="Local worker exited before returning a response",
+                          seconds=time.monotonic() - started)
+            self.close()
+            raise RuntimeError("Local worker exited; cloud fallback is disabled") from None
+        record["seconds"] = time.monotonic() - started
+        if "response" not in result:
+            record.update(status="error", **result)
+            raise RuntimeError("Local inference failed: " + result.get("error", "unknown"))
+        value = result["response"]
+        record.update(status="completed", response=value)
+        return SimpleNamespace(
+            id=value["id"], model=self.model_id,
+            usage=SimpleNamespace(**value["usage"]),
+            choices=[SimpleNamespace(
+                finish_reason=choice["finish_reason"],
+                message=SimpleNamespace(**choice["message"])) for choice in value["choices"]])
+
+    def close(self):
+        if self.process.is_alive():
+            self.process.terminate()
+        self.process.join(timeout=5)
+        self.pipe.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -1,0 +1,3 @@
+--extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
+--only-binary=llama-cpp-python
+llama-cpp-python==0.3.35

--- a/scripts/configure_local.py
+++ b/scripts/configure_local.py
@@ -1,0 +1,36 @@
+"""One-command CPU setup for Linux, macOS and Windows; no model API credentials."""
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+import venv
+
+from setup_local_model import setup
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--venv", default=".venv-local")
+    parser.add_argument("--model-dir", default=".models")
+    parser.add_argument("--config", default=".local/model.json")
+    args = parser.parse_args()
+    environment = (ROOT / args.venv).resolve()
+    python = environment / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+    if not python.exists():
+        venv.EnvBuilder(with_pip=True).create(environment)
+    subprocess.run([
+        str(python), "-m", "pip", "install", "--disable-pip-version-check",
+        "-r", str(ROOT / "requirements-local.txt"),
+    ], cwd=ROOT, check=True)
+    config_path = (ROOT / args.config).resolve()
+    setup(ROOT / args.model_dir, config_path)
+    print("Local inference is configured. Run:")
+    print(f'"{python}" "{ROOT / "experiments/local_inference.py"}" '
+          f'--config "{config_path}" --output reports/my-local-inference')
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup_local_model.py
+++ b/scripts/setup_local_model.py
@@ -1,0 +1,81 @@
+"""Download one pinned GGUF model; inference itself never downloads or calls APIs."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import urllib.request
+
+MODEL_REPOSITORY = "unsloth/Qwen3-4B-Instruct-2507-GGUF"
+MODEL_REVISION = "a06e946bb6b655725eafa393f4a9745d460374c9"
+MODEL_FILENAME = "Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
+MODEL_SHA256 = "3605803b982cb64aead44f6c1b2ae36e3acdb41d8e46c8a94c6533bc4c67e597"
+MODEL_BYTES = 2497281120
+
+
+def file_sha256(path):
+    with Path(path).open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def setup(model_dir, config_path):
+    directory = Path(model_dir).expanduser().resolve()
+    config_path = Path(config_path).expanduser().resolve()
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / MODEL_FILENAME
+    if not path.exists():
+        temporary = path.with_suffix(".gguf.part")
+        url = (f"https://huggingface.co/{MODEL_REPOSITORY}/resolve/"
+               f"{MODEL_REVISION}/{MODEL_FILENAME}")
+        digest = hashlib.sha256()
+        total = 0
+        next_update = 250_000_000
+        with urllib.request.urlopen(url, timeout=45) as response, temporary.open("wb") as stream:
+            while chunk := response.read(4 * 1024 * 1024):
+                stream.write(chunk)
+                digest.update(chunk)
+                total += len(chunk)
+                if total >= next_update:
+                    print(f"Downloaded {total / 1e9:.2f}/{MODEL_BYTES / 1e9:.2f} GB", flush=True)
+                    next_update += 250_000_000
+        if total != MODEL_BYTES or digest.hexdigest() != MODEL_SHA256:
+            raise ValueError("Model size/checksum mismatch; unverified download was not installed")
+        temporary.replace(path)
+    elif path.stat().st_size != MODEL_BYTES or file_sha256(path) != MODEL_SHA256:
+        raise ValueError("Existing model checksum mismatch; file was not overwritten")
+    config = {
+        "backend": "llama_cpp_local_process",
+        "model_path": os.path.relpath(path, config_path.parent),
+        "model_sha256": MODEL_SHA256,
+        "model_repository": MODEL_REPOSITORY,
+        "model_revision": MODEL_REVISION,
+        "context_tokens": 16384,
+        "threads": min(8, os.cpu_count() or 1),
+        "gpu_layers": 0,
+        "seed": 0,
+        "call_timeout_seconds": 240,
+        "cloud_fallback": False,
+    }
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+    print(f"Verified model: {path}", flush=True)
+    print(f"Local configuration: {config_path}", flush=True)
+    return config
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-dir", default=".models")
+    parser.add_argument("--config", default=".local/model.json")
+    args = parser.parse_args()
+    try:
+        setup(args.model_dir, args.config)
+    except (OSError, ValueError) as exc:
+        print(f"Local model setup failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_local_model.py
+++ b/tests/test_local_model.py
@@ -1,0 +1,187 @@
+"""Local inference configuration, transport and failure isolation without model weights."""
+from argparse import Namespace
+import hashlib
+import json
+from pathlib import Path
+import socket
+import sys
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "experiments"))
+import local_inference
+import local_model
+
+
+class LocalModelTests(unittest.TestCase):
+    def config(self, directory):
+        model = Path(directory) / "weights.gguf"
+        model.write_bytes(b"test weights; never loaded by these tests")
+        path = Path(directory) / "config.json"
+        value = {"backend": "llama_cpp_local_process", "model_path": "weights.gguf",
+                 "model_sha256": hashlib.sha256(model.read_bytes()).hexdigest(),
+                 "context_tokens": 8192, "threads": 2, "seed": 0, "gpu_layers": 0,
+                 "call_timeout_seconds": 10, "cloud_fallback": False}
+        path.write_text(json.dumps(value))
+        return path, value, model
+
+    def transport(self, available=True):
+        transport = local_model.LocalTransport.__new__(local_model.LocalTransport)
+        transport.config = {"seed": 0, "call_timeout_seconds": 10}
+        transport.model_id = "local/test"
+        transport.records = []
+        transport.process = Mock()
+        transport.process.is_alive.return_value = True
+        transport.pipe = Mock()
+        transport.pipe.poll.return_value = available
+        transport.pipe.recv.return_value = {"response": {
+            "id": "local-response", "usage": {"prompt_tokens": 20, "completion_tokens": 5, "total_tokens": 25},
+            "choices": [{"finish_reason": "stop", "message": {"role": "assistant", "content": '{"answer":true}'}}]}}
+        return transport
+
+    def request(self):
+        return {"model": "local/test", "messages": [{"role": "system", "content": "Verify"},
+                                                    {"role": "user", "content": "Evidence"}],
+                "max_completion_tokens": 100, "timeout": 5,
+                "response_format": {"type": "json_schema", "json_schema": {"schema": {
+                    "type": "object", "properties": {"answer": {"type": "boolean"}},
+                    "required": ["answer"], "additionalProperties": False}}}}
+
+    def test_config_resolves_relative_weights_and_requires_exact_hash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path, _, model = self.config(tmp)
+            self.assertEqual(str(model), local_model.load_config(path)["model_path"])
+            model.write_bytes(b"changed")
+            with self.assertRaisesRegex(ValueError, "checksum"):
+                local_model.load_config(path)
+
+    def test_config_rejects_cloud_fallback_and_invalid_resources(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path, value, _ = self.config(tmp)
+            for changed in [{"cloud_fallback": True}, {"backend": "openai"}, {"threads": 0}, {"call_timeout_seconds": False}]:
+                path.write_text(json.dumps({**value, **changed}))
+                with self.subTest(changed=changed), self.assertRaises(ValueError):
+                    local_model.load_config(path)
+
+    def test_schema_is_sent_to_local_worker_and_input_is_not_mutated(self):
+        transport = self.transport()
+        request = self.request()
+        original = json.dumps(request)
+        with patch("socket.create_connection", side_effect=AssertionError("HTTP forbidden")):
+            response = transport(**request)
+        sent = transport.pipe.send.call_args.args[0]
+        self.assertEqual(request["response_format"]["json_schema"]["schema"], sent["response_format"]["schema"])
+        self.assertIn('"answer"', sent["messages"][0]["content"])
+        self.assertEqual(original, json.dumps(request))
+        self.assertEqual(20, response.usage.prompt_tokens)
+        self.assertEqual('{"answer":true}', response.choices[0].message.content)
+
+    def test_timeout_terminates_local_worker_without_fallback(self):
+        transport = self.transport(available=False)
+        with self.assertRaises(TimeoutError):
+            transport(**self.request())
+        transport.process.terminate.assert_called_once()
+        self.assertEqual("TimeoutError", transport.records[0]["error_type"])
+
+    def test_sampling_limits_remain_in_original_prompt_and_python_gate(self):
+        transport = self.transport()
+        request = self.request()
+        original = request["response_format"]["json_schema"]["schema"]
+        original["properties"]["answer"] = {"type": "string", "maxLength": 2}
+        transport(**request)
+        sent = transport.pipe.send.call_args.args[0]
+        self.assertNotIn("maxLength", sent["response_format"]["schema"]["properties"]["answer"])
+        self.assertIn('"maxLength":2', sent["messages"][0]["content"])
+        from staged_semantic import _validate
+        with self.assertRaisesRegex(ValueError, "string length"):
+            _validate({"answer": "too long"}, original)
+
+    def test_wrong_model_does_not_send_request(self):
+        transport = self.transport()
+        with self.assertRaisesRegex(ValueError, "differs"):
+            transport(**{**self.request(), "model": "cloud/model"})
+        transport.pipe.send.assert_not_called()
+
+    def test_scoped_decoder_rejects_target_source_as_layer_evidence(self):
+        from prompt_specs import LAYER_CRITIC_SCHEMA
+        from staged_semantic import _validate
+        original = json.dumps(LAYER_CRITIC_SCHEMA)
+        payload = {"target": {"source_version_id": "claim"},
+                   "materials": [{"version_id": "outcome", "content": "Actual result."}]}
+        schema = local_model.scoped_sampling_schema(
+            LAYER_CRITIC_SCHEMA, [{"content": json.dumps(payload)}])
+        answer = {"decision": "repair", "issue": "Check outcome.",
+                  "basis": [{"version_id": "outcome", "quote": "Actual result."}]}
+        _validate(answer, LAYER_CRITIC_SCHEMA)
+        ref_schema = schema["properties"]["basis"]["items"]
+        _validate(answer["basis"][0], ref_schema)
+        answer["basis"][0]["version_id"] = "claim"
+        with self.assertRaises(ValueError):
+            _validate(answer["basis"][0], ref_schema)
+        self.assertEqual(original, json.dumps(LAYER_CRITIC_SCHEMA))
+
+    def test_empty_scope_decoder_cannot_invent_evidence_or_conclusion(self):
+        from prompt_specs import LAYER_SCHEMA
+        from staged_semantic import _validate
+        schema = local_model.scoped_sampling_schema(LAYER_SCHEMA, [{"content": json.dumps({
+            "target": {"source_version_id": "claim"}, "materials": [],
+            "missing_scope": ["outcome"]})}])
+        answer = {"probe_results": [{"probe_number": 1, "basis_pool": [],
+            "dimension_results": [{"dimension": "actor_subject", "verdict": "unresolved",
+                                   "basis_indices": [], "rationale": "Scoped material is missing."}],
+            "gaps": [], "resolutions": [], "stop_reason": "scope_unavailable"}]}
+        _validate(answer, LAYER_SCHEMA)
+        result_schema = schema["properties"]["probe_results"]["items"]["properties"]
+        verdict_schema = result_schema["dimension_results"]["items"]["properties"]["verdict"]
+        result = answer["probe_results"][0]
+        _validate("unresolved", verdict_schema)
+        _validate([], result_schema["basis_pool"])
+        with self.assertRaises(ValueError):
+            _validate("supported", verdict_schema)
+        result["basis_pool"] = [{"version_id": "claim", "quote": "Invented evidence."}]
+        with self.assertRaises(ValueError):
+            _validate(result["basis_pool"], result_schema["basis_pool"])
+
+    def test_worker_disables_network_before_loading_and_generating(self):
+        checks = []
+        class FakeLlama:
+            def __init__(self, **kwargs):
+                with self_test.assertRaisesRegex(RuntimeError, "Network access"):
+                    socket.socket()
+                checks.append("load")
+            def create_chat_completion(self, **kwargs):
+                with self_test.assertRaisesRegex(RuntimeError, "Network access"):
+                    socket.create_connection(("example.com", 443))
+                checks.append("generate")
+                return {"output": "local"}
+            def close(self):
+                checks.append("closed")
+        self_test = self
+        pipe = Mock()
+        pipe.recv.side_effect = [{"messages": []}, None]
+        config = {"model_path": "test", "context_tokens": 100, "threads": 1, "gpu_layers": 0, "seed": 0}
+        with patch.dict(sys.modules, {"llama_cpp": SimpleNamespace(Llama=FakeLlama)}), \
+                patch.object(socket, "socket", socket.socket), \
+                patch.object(socket, "create_connection", socket.create_connection):
+            local_model._worker(pipe, config)
+        self.assertEqual(["load", "generate", "closed"], checks)
+
+    def test_missing_model_stays_local_and_writes_explicit_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            args = Namespace(inputs=str(ROOT / "experiments/historical-2023-pilot2-v3/inputs.json"),
+                             output=str(Path(tmp) / "run"), case=None, config="missing.json",
+                             semantic_mode="staged", max_rounds=1, max_calls=20, case_seconds=60,
+                             include_controls=False)
+            with patch.object(local_inference, "LocalTransport", side_effect=FileNotFoundError("missing model")):
+                self.assertEqual(1, local_inference.run(args))
+            status = json.loads((Path(args.output) / "status.json").read_text())
+            self.assertEqual("local_runtime_error", status["status"])
+            self.assertEqual(0, status["cloud_api_calls"])
+            self.assertFalse(status["fallback"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fresh verification currently depends on a hosted model, so repeated local checks consume billed model tokens. This adds a CPU runner that loads pinned GGUF weights in a local process and passes its fresh responses through the existing verification adapters.

- Add one-command environment/model setup for Qwen3-4B-Instruct-2507 Q4_K_M, pinned by revision and SHA-256.
- Generate with llama-cpp-python 0.3.35 directly: no OpenAI SDK, HTTP inference endpoint, API key, or cloud fallback.
- Bound the worker lifetime, block Python networking in the worker, and preserve raw requests, outputs, token usage, traces, and errors.
- Restrict evidence references to supplied layer material IDs and retain the original schema, quote, scope, and grounding gates. Decoder length bounds are omitted to avoid native grammar expansion limits; the original Python gates still enforce them.

Validation on Linux x86_64, Python 3.12, 8 CPU cores:
- 269 unit tests passed; release manifest verified 373 files; whitespace check passed.
- Installed and SHA-verified the 2.50 GB model and ran the setup wrapper successfully in an environment without the OpenAI SDK.
- Real local generations made zero cloud model calls. The staged Lucid diagnostics still fail semantic citation/scope checks with this small model. A targeted empty-scope generation respected empty source references and unresolved verdicts, but failed the original array-cardinality gate. These are retained failures, not an end-to-end success or an accuracy result.

This draft is stacked on #4 (`codex/local-verification-status`). It adds fresh inference alongside the archived-response replay workflow.

Tested source tree: `bf245a487bf10c4a664ae943fdf51aea08357544`.

From the repository root:
```bash
python3 scripts/configure_local.py
.venv-local/bin/python experiments/local_inference.py --config .local/model.json --output reports/my-local-inference
```
