### PR TITLE
Show early risk comparison in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,43 @@ Version 0.2.0: a bounded, auditable news provenance loop with **decomposition on
 
 Repository Discussions are enabled, and the repository includes a prepared **Accuracy decline** reporting form for reproducible metric regressions or weaker trace outcomes. Reports should identify the affected metric or behavior, include the run configuration, and avoid treating synthetic fixtures as real-world performance evidence.
 
+## Latest local historical comparison
+
+The September 11 development run compared `gpt-5.6-luna` directly with the
+same model inside the new single-pass provenance-risk harness. Both used the
+local Codex-login route at low reasoning. The inference batch contained only
+material available by December 31, 2023; the 2025 fabrication findings were
+kept outside inference and loaded only during scoring.
+
+| Measure | Direct Luna | Luna + single-pass harness | Registered goal |
+|---|---:|---:|---:|
+| Strict cutoff fact accuracy | 2/8 (25%) | **8/8 (100%)** | ≥6/8 (75%) |
+| Later-false cases identified early | 0/4¹ | **4/4** | 4/4 |
+| Control cases flagged high risk | — | **0/4** | diagnostic |
+| Model calls | 8 | 8 | ≤ one/case |
+| Input + output tokens | 164,490 | **64,444** | ≤328,980 |
+| Harness / direct token ratio | 1.00× | **0.39×** | ≤2.00× |
+
+**All three registered goals were met.** The harness separates the historical
+fact verdict from a predictive provenance-risk signal. A high-risk output means
+that a real-world data-provenance claim has only self-attestation in the bounded
+packet; it does not mean the pre-2024 evidence proved fabrication.
+
+¹ The direct baseline had no separate risk output, and none of its cutoff fact
+verdicts identified the four claims later shown to involve fabrication.
+
+Read the [complete comparison, per-case table, limitations and reproducibility
+record](reports/early-risk-total-20260911/README.md). These eight previously
+observed development cases cover two event families. The attribution controls
+do not measure false-positive risk on independently authenticated experiments,
+so this result does not establish general accuracy on unseen news.
+
+Run the single-pass path through the local tunnel with:
+
+```bash
+python -m factcircuit early-risk CASE.json --model gpt-5.6-luna --reasoning-effort low --output RESULT.json
+```
+
 ## Run
 
 Python 3.11+; standard library only. From this project directory:

--- a/RELEASE_MANIFEST.json
+++ b/RELEASE_MANIFEST.json
@@ -45,8 +45,8 @@
     },
     {
       "path": "README.md",
-      "bytes": 13581,
-      "sha256": "aaabe56c4a92c02d66644a5e015d38074fa865cf1d3e0400aeefb1f5e6a83545"
+      "bytes": 15467,
+      "sha256": "c5b0e8d919dc53095372a6cb816c2d992ac22d9018a17185fac310d185e54ec5"
     },
     {
       "path": "SECURITY.md",


### PR DESCRIPTION
Adds the successful September 11 local comparison directly to the repository README, including the 8/8 strict cutoff result, 4/4 later-false risk flags, 64,444-token total, full-report link, local command, and development-set limitations.

Validation: 461 tests pass locally and the release manifest is current.
