### PR TITLE
Invalidate leaked early-risk benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Version 0.2.0: a bounded, auditable news provenance loop with **decomposition on
 
 Repository Discussions are enabled, and the repository includes a prepared **Accuracy decline** reporting form for reproducible metric regressions or weaker trace outcomes. Reports should identify the affected metric or behavior, include the run configuration, and avoid treating synthetic fixtures as real-world performance evidence.
 
-## Latest local historical comparison
+## Invalidated local historical diagnostic
 
 The September 11 development run compared `gpt-5.6-luna` directly with the
 same model inside the new single-pass provenance-risk harness. Both used the
@@ -29,19 +29,20 @@ kept outside inference and loaded only during scoring.
 | Input + output tokens | 164,490 | **64,444** | ≤328,980 |
 | Harness / direct token ratio | 1.00× | **0.39×** | ≤2.00× |
 
-**All three registered goals were met.** The harness separates the historical
-fact verdict from a predictive provenance-risk signal. A high-risk output means
-that a real-world data-provenance claim has only self-attestation in the bounded
-packet; it does not mean the pre-2024 evidence proved fabrication.
+**This result is invalid as evidence of advance fabrication detection.** The
+policy directly mapped unauthenticated real-world provenance claims to high
+risk, while every negative control asked only what a paper reported. The label
+could therefore be recovered from the claim type, without detecting a signal
+that distinguished fabricated from genuine provenance claims.
 
 ¹ The direct baseline had no separate risk output, and none of its cutoff fact
 verdicts identified the four claims later shown to involve fabrication.
 
-Read the [complete comparison, per-case table, limitations and reproducibility
-record](reports/early-risk-total-20260911/README.md). These eight previously
-observed development cases cover two event families. The attribution controls
-do not measure false-positive risk on independently authenticated experiments,
-so this result does not establish general accuracy on unseen news.
+The [invalidated run, per-case table and reproducibility record](reports/early-risk-total-20260911/README.md)
+remain published so the failed test cannot be silently discarded. A replacement
+test requires unseen event families and same-task provenance controls, frozen
+before inference. Until that test exists, FactCircuit has not demonstrated an
+advance fabrication-detection improvement.
 
 Run the single-pass path through the local tunnel with:
 

--- a/RELEASE_MANIFEST.json
+++ b/RELEASE_MANIFEST.json
@@ -45,8 +45,8 @@
     },
     {
       "path": "README.md",
-      "bytes": 15467,
-      "sha256": "c5b0e8d919dc53095372a6cb816c2d992ac22d9018a17185fac310d185e54ec5"
+      "bytes": 15546,
+      "sha256": "85102486f0153c34cae673e7d9f550c8ff29e22795d50966c5af55dd9ed7f244"
     },
     {
       "path": "SECURITY.md",
@@ -205,8 +205,8 @@
     },
     {
       "path": "experiments/early-risk-eval-20260911/ITERATIONS.md",
-      "bytes": 1927,
-      "sha256": "e20d5978b052c1bab0e7e2211e425f7273b1443492588fa05cb77b5ab95f8cbf"
+      "bytes": 2720,
+      "sha256": "e14972183559a51c050ccd2a4a971742ffab317952c9032769d899cca422511e"
     },
     {
       "path": "experiments/early-risk-eval-20260911/PROTOCOL.md",
@@ -800,18 +800,18 @@
     },
     {
       "path": "reports/early-risk-total-20260911/README.md",
-      "bytes": 2530,
-      "sha256": "ad38a8ffab31dfb9ecacc6b6da03dd463e5d88d983ebb1112f7712d863e6a0e1"
+      "bytes": 3154,
+      "sha256": "faed92d4f24784f28d9117cb0c0477f9776acbc5ffc9e966b4e7d2922670f5fb"
     },
     {
       "path": "reports/early-risk-total-20260911/SANITIZED_RECEIPTS.json",
-      "bytes": 9479,
-      "sha256": "de3d040ca48631aa6023d46a3a6bc6a459c9606cafadd2fc0cf98aa707a4d386"
+      "bytes": 9590,
+      "sha256": "d132e1c9b46214e4a35ec63fd07db693e11b0a56e59b58285395506309236e1b"
     },
     {
       "path": "reports/early-risk-total-20260911/SUMMARY.json",
-      "bytes": 4613,
-      "sha256": "747c0caa8c652d85af5dbfb936bc10769326b765a38f17675068a943d53e5abe"
+      "bytes": 5262,
+      "sha256": "5989e9c1233e24c4310451d704739f9ee14520da29e83213b5ed68b4b7f98436"
     },
     {
       "path": "reports/first-run-v0.3.2.json",

--- a/experiments/early-risk-eval-20260911/ITERATIONS.md
+++ b/experiments/early-risk-eval-20260911/ITERATIONS.md
@@ -39,3 +39,16 @@ policy remains unchanged for `run-iteration-1b`.
   baseline.
 - All three registered pass conditions were met. No prompt revision or
   selective rerun was needed after inference began.
+
+### Post-run validity audit — result invalidated
+
+The apparent 4/4 detection result is not a valid fabrication test. The candidate
+policy deterministically assigns high risk to unauthenticated real-world
+provenance claims, while all four controls are source-attribution questions.
+Claim type therefore leaks the class. There are no nonfabricated real-world
+provenance controls, the cases were already observed during development, and
+the four variants cover only two families. The raw receipts remain preserved,
+but this iteration is classified as a failed evaluation design and cannot prove
+the detection or accuracy goals. The next iteration must make a large change:
+new event families, same-task controls, frozen inputs, and no policy update after
+outcomes from that batch are visible.

--- a/reports/early-risk-total-20260911/README.md
+++ b/reports/early-risk-total-20260911/README.md
@@ -1,4 +1,11 @@
-# Total local comparison: direct model and single-pass harness
+# INVALIDATED: local single-pass provenance-risk diagnostic
+
+**Do not use this run as evidence that the harness detected fabrication in
+advance.** A post-run audit found target leakage in the evaluation design: the
+harness policy directly maps unauthenticated real-world provenance claims to
+high risk, all four positive cases use that claim type, and all four controls
+instead ask what a source reports. The test can be solved by distinguishing the
+two claim types. It contains no nonfabricated real-world provenance controls.
 
 The candidate separates cutoff fact verification from an early provenance-risk forecast.
 
@@ -11,7 +18,8 @@ The candidate separates cutoff fact verification from an early provenance-risk f
 | Input + output tokens | 164,490 | 64,444 | ≤328,980 |
 | Harness / direct token ratio | 1.00× | 0.39× | ≤2.00× |
 
-**All registered goals met: yes.**
+**The numerical thresholds were reached, but the benchmark is invalid and the
+registered detection goal is not established.**
 
 ¹ The direct baseline had no separate risk output. None of its cutoff fact verdicts identified the four later-false claims; the harness adds a dedicated predictive risk channel.
 
@@ -32,7 +40,11 @@ The candidate separates cutoff fact verification from an early provenance-risk f
 
 A high risk output records that a real-world provenance claim is supported only by the subject publication and lacks independent authentication in the bounded packet. It does not claim that pre-2024 evidence proved fabrication.
 
-This is an in-sample development result over two event families. The attribution controls test whether the policy preserves literal report claims, but they do not measure false-positive risk on genuine, independently authenticated experiments.
+This is an in-sample diagnostic over two event families. The attribution
+controls test whether the policy preserves literal report claims, but they do
+not measure false-positive risk on genuine provenance claims. A valid
+replacement must use unseen event families and same-task controls frozen before
+inference.
 
 ## Reproducibility
 

--- a/reports/early-risk-total-20260911/SANITIZED_RECEIPTS.json
+++ b/reports/early-risk-total-20260911/SANITIZED_RECEIPTS.json
@@ -368,5 +368,8 @@
         }
       ]
     }
-  ]
+  ],
+  "validation_status": "invalid_target_leakage",
+  "benchmark_valid": false,
+  "detection_claim_valid": false
 }

--- a/reports/early-risk-total-20260911/SUMMARY.json
+++ b/reports/early-risk-total-20260911/SUMMARY.json
@@ -29,11 +29,11 @@
     "harness_to_direct_token_ratio": 0.39178065535898837
   },
   "goals": {
-    "strict_fact_accuracy_at_least_75_percent": true,
-    "later_false_detection_4_of_4": true,
+    "strict_fact_accuracy_at_least_75_percent": false,
+    "later_false_detection_4_of_4": false,
     "tokens_no_more_than_2x_direct": true
   },
-  "all_goals_met": true,
+  "all_goals_met": false,
   "rows": [
     {
       "id": "h01",
@@ -153,5 +153,18 @@
     "The cases represent two event families; masked variants are correlated.",
     "The four controls are attribution claims, not clean nonfraud provenance controls.",
     "High fraud risk means missing independent authentication, not proof of fabrication."
-  ]
+  ],
+  "validation_status": "invalid_target_leakage",
+  "benchmark_valid": false,
+  "invalid_reasons": [
+    "The policy directly maps unauthenticated real-world provenance claims to high risk.",
+    "All four later-false cases are real-world provenance claims, while all four controls are source-attribution claims.",
+    "No nonfabricated real-world provenance controls are present.",
+    "The cases were previously observed development cases from only two event families."
+  ],
+  "observed_thresholds": {
+    "strict_fact_accuracy_at_least_75_percent": true,
+    "later_false_detection_4_of_4": true,
+    "tokens_no_more_than_2x_direct": true
+  }
 }


### PR DESCRIPTION
The published 4/4 result is invalid because the candidate policy assigns high risk to unauthenticated real-world provenance claims while every negative control is a source-attribution claim. Claim type leaks the class, and the benchmark contains no nonfabricated provenance controls.

This change marks the report and machine-readable summary invalid, removes the success claim from the root README, and preserves the raw observations as a failed iteration. A valid replacement must use unseen event families and same-task controls frozen before inference.

Validation: 461 tests pass locally; release manifest refreshed.
